### PR TITLE
Fix missing publish task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
    alias(libs.plugins.kotlin.jvm)
+   id("kotest-publishing-conventions")
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -19,8 +19,6 @@ version = Ci.version
 
 val publications: PublicationContainer = (extensions.getByName("publishing") as PublishingExtension).publications
 
-val ossrhUsername: String by project
-val ossrhPassword: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -47,8 +45,8 @@ publishing {
          name = "deploy"
          url = if (Ci.isRelease) releasesRepoUrl else snapshotsRepoUrl
          credentials {
-            username = System.getenv("OSSRH_USERNAME") ?: ossrhUsername
-            password = System.getenv("OSSRH_PASSWORD") ?: ossrhPassword
+            username = System.getenv("OSSRH_USERNAME") ?: ""
+            password = System.getenv("OSSRH_PASSWORD") ?: ""
          }
       }
    }


### PR DESCRIPTION
My apologies, I forgot to apply the new publishing convention plugin to the build. This is why we were missing the `publish` task in the [master](https://github.com/kotest/kotest-extensions-embedded-kafka/actions/runs/4138570263/jobs/7155132117#step:5:42) action. I validated that the task is available from the project root using `./gradlew tasks --all`. Everything should be good now for publishing.